### PR TITLE
Correctly set message for ApiErrors with non-named args

### DIFF
--- a/lib/worldnet_payments/api_error.rb
+++ b/lib/worldnet_payments/api_error.rb
@@ -31,6 +31,8 @@ module WorldnetPayments
           instance_variable_set "@#{k}", v
         end
       else
+        @message = arg
+
         super arg
       end
     end

--- a/lib/worldnet_payments/api_error.rb
+++ b/lib/worldnet_payments/api_error.rb
@@ -46,7 +46,7 @@ module WorldnetPayments
       if @message.nil?
         msg = "Error message: the server returns an error"
       else
-        msg = @message
+        msg = @message.to_s
       end
 
       msg += "\nHTTP status code: #{code}" if code

--- a/spec/api_error_spec.rb
+++ b/spec/api_error_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe WorldnetPayments::ApiError do
+  it 'parses non-named arguments as the message' do
+    expect(WorldnetPayments::ApiError.new('Connection timed out').to_s).to eq 'Connection timed out'
+  end
+end


### PR DESCRIPTION
Non-named arguments were previously being ignored and defaulting to `"Error message: the server returns an error"`